### PR TITLE
Ansible: add cluster configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.qcow2 filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A configuration file is provided on the utils/ directory and contains all the gl
 
 Host IP can be configured with the `HOST_X_IP` environment variables.
 
-## Run the tests with cqfd
+## Cqfd
 
 [cqfd](https://github.com/savoirfairelinux/cqfd) is a quick and convenient way to run commands in the current directory, but within a pre-defined Docker container.
 cqfd is used with Xvfb to run selenium without display.
@@ -26,11 +26,36 @@ $ cd cqfd
 $ sudo make install
 ```
 
-* Use cqfd
+* Initialize cqfd
 
 `cqfd init`
 
-NOTE: The step above is only required once
+NOTE: The cluster configuration and Selenium tests use both cqfd with different docker containers.
+Each of them will require executing the command below once.
+
+## Configure the cluster
+
+- Flash all the hosts with a [Seapath Debian image](https://github.com/seapath/build_debian_iso) containing Cockpit
+- Clone the repository [Seapath ansible](https://github.com/seapath/ansible) and checkout on the debian-main branch
+- Move or clone the cockpit-plugin-tests repository in the ansible/tests directory
+- Deploy the cluster and install the 3 plugins
+```
+$ cd ansible
+$ cqfd init
+$ cqfd run ansible-playbook -i tests/cockpit-plugin-tests/ansible/inventory/cluster_definition.yml --skip-tags "package-install" tests/cockpit-plugin-tests/ansible/deploy_cluster_test_plugins.yml
+```
+- Deploy a VM
+```
+$ cqfd run ansible-playbook -i tests/cockpit-plugin-tests/ansible/inventory/cluster_definition.yml -i tests/cockpit-plugin-tests/ansible/inventory/vm_definition.yml playbooks/deploy_vms_cluster.yaml
+```
+- Shutdown one of the host
+
+NOTE: to restart the host remotely, you will need the wakeonlan package and the following command:
+```
+$ wakeonlan <MAC_ADDRESS>
+```
+
+## Run the tests with cqfd
 
 `cqfd -b <flavour_name>`
 

--- a/ansible/deploy_cluster_test_plugins.yml
+++ b/ansible/deploy_cluster_test_plugins.yml
@@ -1,0 +1,40 @@
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# ansible_repository_path can be set in the inventory or via the argument "-e"
+- import_playbook: "{{ ansible_repository_path | default('../../../..') }}/playbooks/cluster_setup_debian.yaml"
+
+- name: Fetch and build plugins
+  hosts:
+      - builder
+  vars_files:
+    - roles/cockpit_plugins_cluster_setup/vars/main.yml
+  tasks:
+      - name: Cockpit plugins installation
+        include_tasks: roles/cockpit_plugins_cluster_setup/tasks/fetch_plugins.yml
+
+      - name: Cockpit plugins installation
+        include_tasks: roles/cockpit_plugins_cluster_setup/tasks/build_plugins.yml
+
+- name: Configure the cluster for Cockpit plugins testing
+  hosts:
+      - cluster_machines
+  vars_files:
+    - roles/cockpit_plugins_cluster_setup/vars/main.yml
+  tasks:
+      - name: Check if cockpit is installed
+        command: which cockpit-bridge
+        register: cockpit_status
+
+      - name: Cockpit plugins installation
+        become: true
+        block:
+          - include_tasks: roles/cockpit_plugins_cluster_setup/tasks/deploy_plugins_cluster.yml
+        when: cockpit_status.rc == 0
+
+        # For Selenium tests purposes
+      - name: Shutdown one of the host
+        command: "shutdown now"
+        become: true
+        when: inventory_hostname == 'nuc3'

--- a/ansible/inventory/cluster_definition.yml
+++ b/ansible/inventory/cluster_definition.yml
@@ -1,0 +1,160 @@
+# Copyright (C) 2020-2024, RTE (http://www.rte-france.com)
+# Copyright (C) 2023-2024, SFL (https://savoirfairelinux.com)
+# SPDX-License-Identifier: Apache-2.0
+
+---
+all:
+    children:
+        builder:
+            hosts:
+                localhost:
+                    ansible_connection: local
+
+                # build_machine:
+                #     ansible_host: <IP>
+                #     ansible_user: <user>
+
+        cluster_machines:
+            children:
+                hypervisors:
+                    hosts:
+                        nuc1:
+                            # ansible variables
+                            ansible_host: 192.168.216.135
+                        nuc2:
+                            # ansible variables
+                            ansible_host: 192.168.216.136
+                        nuc3:
+                            # ansible variables
+                            ansible_host: 192.168.216.137
+
+                    # hypervisors common vars
+                    vars:
+                        network_interface: enp88s0 #main interface
+                        ip_addr: "{{ ansible_host }}"
+
+        # Ceph groups
+        # All machines in the cluster must be part of mons groups
+        mons:
+            hosts:
+                nuc1:
+                nuc2:
+                nuc3:
+        # Machines that will be used as OSDs (which will store data)
+        osds:
+            hosts:
+                nuc1:
+                nuc2:
+                nuc3:
+
+            vars:
+                # Ceph settings
+                # ceph_osd_disk needs to be set to the "/dev/disk/by-path/" link of the disk used by the osd
+                ceph_osd_disk: "/dev/disk/by-path/pci-0000:01:00.0-nvme-1"
+                # Required variables by ceph-ansible:
+                lvm_volumes: # One disk installation. Create a 100 GiB partition for Ceph.
+                    - data: lv_ceph # Name of the logical volume to use for the CEPH OSD volume
+                      data_vg: vg_ceph # Name of the volume group to use for the CEPH OSD volume
+                      data_size: 80G # Size of the logical volume, default in megabytes, possible values: [0-9]+[bBsSkKmMgGtTpPeE]
+                      device: "{{ ceph_osd_disk }}"
+                      device_number: 3 # Number of the partition in the ceph_osd_disk
+                      device_size: 100GiB # Size of the partition in the ceph_osd_disk, default in megabytes, possible units: B, KB, KiB, MB, MiB, GB, GiB, TB, TiB
+
+        clients:
+            hosts:
+                nuc1:
+                nuc2:
+                nuc3:
+            vars:
+              # Required variables by ceph-ansible.
+              # These are SEAPATH needed overrides. Do not change unless you know exactly what you are doing
+              user_config: true
+              rbd:
+                name: "rbd"
+                application: "rbd"
+                pg_autoscale_mode: on
+                target_size_ratio: 1
+              pools:
+                - "{{ rbd }}"
+              keys:
+                - name: client.libvirt
+                  caps:
+                    mon: 'profile rbd, allow command "osd blacklist"'
+                    osd: "allow class-read object_prefix rbd_children, profile rbd pool=rbd"
+                  mode: "{{ ceph_keyring_permissions }}"
+
+    # Common vars for all hosts
+    vars:
+        # Ansible vars
+        ansible_connection: ssh
+        ansible_user: ansible
+        ansible_python_interpreter: /usr/bin/python3
+        ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+        ansible_remote_tmp: /tmp/.ansible/tmp
+
+        # Main network configuration
+        gateway_addr: 192.168.216.1
+        dns_servers: "192.168.216.1"
+        apply_network_config: false # do we restart the ovs_config script to apply the changes to the ovs topology (default: false)
+        #skip_reboot_setup_network: true # if we do not apply the changes (apply_network_config=false), then the network playbook will reboot the servers at the end. You can choose to skip this reboot here (default: false). It is recommended to let it to false except if you fully understand the network configuration process.
+        skip_recreate_team0_config: true # one network configuration
+        remove_all_networkd_config: true  # if defined and true, the network playbook will start by wiping the /etc/systemd/network/ directory content, this can help cleaning old conflicting files.
+
+        ntp_servers:
+            - "192.168.216.1"
+
+        # Ceph settings
+        # Required variables by ceph-ansible.
+        # These are SEAPATH needed overrides. Do not change unless specified (osd_pool_default*) or you know exactly what you are doing
+        configure_firewall: false
+        ntp_service_enabled: true
+        ceph_origin: distro
+        monitor_address: "{{ ansible_host }}"
+        public_network: "192.168.216.0/24"
+        cluster_network: "{{ public_network }}"
+        ceph_conf_overrides:
+          global:
+            osd_pool_default_size: 3 # to be set to the number storage nodes
+            osd_pool_default_min_size: 2 # to be set to the number of nodes - the number of nodes we are allowing ourselve to lose = the minimum number of nodes needed online for the pool to be available
+            osd_pool_default_pg_num: 128
+            osd_pool_default_pgp_num: 128
+            osd_crush_chooseleaf_type: 1
+            mon_osd_min_down_reporters: 1
+          mon:
+            auth_allow_insecure_global_id_reclaim: false
+          osd:
+            osd_min_pg_log_entries: 500
+            osd_max_pg_log_entries: 500
+            osd memory target: 8076326604
+        dashboard_enabled: false
+
+
+        vm_directory: "/mnt/seapath/vm/"
+        vms_disks_directory: "{{ vm_directory }}"
+        vms_config_directory: "{{ vm_directory }}"
+
+        # Grub password
+        # The password hash generated with "grub-mkpasswd-pbkdf2 -c 65536 -s 256 -l 64", in this example the pass is "toto"
+        grub_password: grub.pbkdf2.sha512.65536.E291D66AEEB3C22BD6B019C5C3587A3094AE93D61E20D134EC6324925AE5045DCA61EF30B3BD04B4D6F7360B9C9B242AA68B1643CCB269C53658EC959B5964ADB9C9D5FAA280A291D8F95E3F255254A4119A2431AFE797F1949EE4FBBC4C74281C550C83DAED26C254224061BEFCEEBF8091A8D1BE406EBB3A3E8A519E36B4FE161BE191D407193E5DFEBCC09F8822B4060EA9CD1E6B8677D40D32826EF025CA494BCD209032F7CF2A4A2E74717E6D17E87A62AAA93E458C96F983E69FBFC4FD602403988EAF5AADCA4B5B145B0F6C6FFB53F55CD6C56C15C17B2F8A5B3A214F3140470566597760D9388084AE978DB5C0EBF7C868A855DB38DACA47A010417A.FDA0C3188FAC87FFA04D862AC9B1020F29FEEA3B9590BE534330D8C7CAB71444CBF527E39D7DAE640545139202B9CA77822CCE21AB1134110F6AF3EFD793E848
+
+
+        # Extra kernel modules to be loaded at boot (you may need this depending on your hardware)
+        extra_kernel_modules: []
+
+        apt_repo:
+          - http://ftp.fr.debian.org/debian bookworm main contrib non-free non-free-firmware
+          - http://security.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
+          - http://ftp.fr.debian.org/debian bookworm-backports main contrib non-free non-free-firmware
+          - https://artifacts.elastic.co/packages/8.x/apt stable main
+
+        # Default user with admin privileges, and password hash
+        admin_user: virtu
+        # SSH public keys for the admin_user
+        # admin_ssh_keys:
+        # account used for libvirt live-migration
+        livemigration_user: livemigration
+        interface_to_wait_for: br0
+
+        extra_crm_cmd_to_run: |
+                  primitive ptpstatus_test ocf:seapath:ptpstatus op monitor timeout=10 interval=10 op_params multiplier=1000
+                  clone cl_ptpstatus_test ptpstatus_test meta target-role=Started

--- a/ansible/inventory/vm_definition.yml
+++ b/ansible/inventory/vm_definition.yml
@@ -1,0 +1,23 @@
+# Copyright (C) 2020-2024, RTE (http://www.rte-france.com)
+# Copyright (C) 2023-2024, SFL (https://savoirfairelinux.com)
+# SPDX-License-Identifier: Apache-2.0
+
+---
+all:
+  children:
+    VMs:
+      hosts:
+        guest3:
+          description: "Simple VM"
+          ansible_host: 192.168.216.138
+          vm_template: "../templates/vm/guest.xml.j2"
+          pinned_host: nuc3
+          vm_disk: "../src/cockpit-plugin-tests/ansible/roles/cockpit_plugins_cluster_setup/files/Yocto.qcow2"
+          disk_extract: false
+          vm_features: []
+          bridges:
+            - name: "br0"
+              mac_address: "52:54:00:c4:f9:34"
+      vars:
+        ansible_user: virtu
+        ip_addr: "{{ ansible_host }}"

--- a/ansible/roles/cockpit_plugins_cluster_setup/files/Yocto.qcow2
+++ b/ansible/roles/cockpit_plugins_cluster_setup/files/Yocto.qcow2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01864ae2338b586965b55e6ee9d8d0f56046c99b08cf6fd75aadd9a0cae44930
+size 573505536

--- a/ansible/roles/cockpit_plugins_cluster_setup/tasks/build_plugins.yml
+++ b/ansible/roles/cockpit_plugins_cluster_setup/tasks/build_plugins.yml
@@ -1,0 +1,12 @@
+# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: build plugins
+  block:
+    - name: Build Cockpit cluster dashboard
+      command: "npm run init --prefix {{ cockpit_plugins_location }}/cockpit-cluster-dashboard"
+    - name: Build Cockpit update
+      command: "npm run init --prefix {{ cockpit_plugins_location }}/cockpit-update"
+    - name: Build Cockpit cluster vm management
+      command: "npm run init --prefix {{ cockpit_plugins_location }}/cockpit-cluster-vm-management"

--- a/ansible/roles/cockpit_plugins_cluster_setup/tasks/deploy_plugins_cluster.yml
+++ b/ansible/roles/cockpit_plugins_cluster_setup/tasks/deploy_plugins_cluster.yml
@@ -1,0 +1,26 @@
+# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Install plugins
+  block:
+  - name: copy plugin (dashboard)
+    ansible.builtin.copy:
+      src: "{{ cockpit_plugins_location }}/cockpit-cluster-dashboard/dist/"
+      dest: "{{ cockpit_plugin_installation_path }}/cockpit-cluster-dashboard"
+      mode: '644'
+      owner: root
+
+  - name: copy plugin (update)
+    ansible.builtin.copy:
+      src: "{{cockpit_plugins_location}}/cockpit-update/dist/"
+      dest: "{{ cockpit_plugin_installation_path }}/cockpit-cluster-update"
+      mode: '644'
+      owner: root
+
+  - name: copy plugin (vm management)
+    ansible.builtin.copy:
+      src: "{{cockpit_plugins_location}}/cockpit-cluster-vm-management/dist/"
+      dest: "{{ cockpit_plugin_installation_path }}/cockpit-cluster-vm-management"
+      mode: '644'
+      owner: root

--- a/ansible/roles/cockpit_plugins_cluster_setup/tasks/fetch_plugins.yml
+++ b/ansible/roles/cockpit_plugins_cluster_setup/tasks/fetch_plugins.yml
@@ -1,0 +1,18 @@
+# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Fetch plugins
+  block:
+    - name: Clone Cockpit cluster dashboard repository
+      ansible.builtin.git:
+        repo: https://github.com/seapath/cockpit-cluster-dashboard
+        dest:  "{{ cockpit_plugins_location }}/cockpit-cluster-dashboard"
+    - name: Clone Cockpit update repository
+      ansible.builtin.git:
+        repo: https://github.com/seapath/cockpit-update
+        dest: "{{ cockpit_plugins_location }}/cockpit-update"
+    - name: Clone Cockpit cluster vm management repository
+      ansible.builtin.git:
+        repo: https://github.com/seapath/cockpit-cluster-vm-management
+        dest:  "{{ cockpit_plugins_location }}/cockpit-cluster-vm-management"

--- a/ansible/roles/cockpit_plugins_cluster_setup/vars/main.yml
+++ b/ansible/roles/cockpit_plugins_cluster_setup/vars/main.yml
@@ -1,0 +1,6 @@
+# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# SPDX-License-Identifier: Apache-2.0
+
+---
+cockpit_plugin_installation_path: "/usr/share/cockpit"
+cockpit_plugins_location: "../../.."


### PR DESCRIPTION
It is now possible to configure the cluster, install the cockpit plugins and test them from a fresh install of the Seapath Debain distribution.