### PR TITLE
ci: add GitHub workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI Cockpit plugins
+
+env:
+  WORK_DIR: /tmp/seapath_ci_${{ github.run_id }}_${{ github.run_attempt }}_${{ github.sha }}
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches: [main]
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  actions: write
+  checks: write
+
+jobs:
+  setup:
+    runs-on: runner-SFL
+
+    steps:
+    - name: Initialize sources
+      run: |
+        mkdir ${{ env.WORK_DIR }}; cd ${{ env.WORK_DIR }};
+        git clone -q -b debian-main https://github.com/seapath/ansible.git ansible;
+        ####### -- Lien avec qcow2 (ln) qui doit être placé dans le runner à une place fixe
+        git clone -q -b main https://github.com/seapath/cockpit-plugin-tests.git ansible/tests/cockpit-plugin-tests;
+        echo "CI sources downloaded successfully";
+
+    - name: Configure the cluster & deploy a VM
+      run: |
+        cd ${{ env.WORK_DIR }}/ansible;
+        cqfd init;
+        cqfd -b prepare;
+        cqfd run ansible-playbook -i tests/cockpit-plugin-tests/ansible/inventory/cluster_definition.yml --skip-tags "package-install" tests/cockpit-plugin-tests/ansible/deploy_cluster_test_plugins.yml;
+        cqfd run ansible-playbook -i tests/cockpit-plugin-tests/ansible/inventory/cluster_definition.yml -i tests/cockpit-plugin-tests/ansible/inventory/vm_definition.yml playbooks/deploy_vms_cluster.yaml;
+
+    - name: Launch Cockpit plugins tests
+      run: |
+        cd ${{ env.WORK_DIR }}/ansible/tests/cockpit-plugin-tests;
+        cqfd init
+        cqfd -b all_tests
+
+    - name: Wake up the shutdown host
+      run: |
+        wakeonlan 54:B2:03:9F:50:8A
+
+    - name: Clean
+      run: rm -rf ${{ env.WORK_DIR }};
+

--- a/ansible/deploy_cluster_test_plugins.yml
+++ b/ansible/deploy_cluster_test_plugins.yml
@@ -3,7 +3,7 @@
 
 ---
 # ansible_repository_path can be set in the inventory or via the argument "-e"
-- import_playbook: "{{ ansible_repository_path | default('../../../..') }}/playbooks/cluster_setup_debian.yaml"
+- import_playbook: "{{ ansible_repository_path | default('../../..') }}/playbooks/cluster_setup_debian.yaml"
 
 - name: Fetch and build plugins
   hosts:


### PR DESCRIPTION
  This workflow is executed after each pull request and performs the
  following operations:
   
  - Deploy a cluster SEAPATH Debian
  - Configure the cluster (deploy a VM and shutdown one node)
  - Run the Selenium tests
  - Wake up the node and clean the workspace
